### PR TITLE
Make specificity higher for /_errors/

### DIFF
--- a/snippets/error_pages.conf
+++ b/snippets/error_pages.conf
@@ -26,7 +26,7 @@ error_page 506 /506.html;
 error_page 507 /507.html;
 error_page 508 /508.html;
 
-location /_errors/ {
+location ^~ /_errors/ {
         root /srv/http/default;
         allow all;
 }


### PR DESCRIPTION
Without this it did not work for me in my configuration. My issue was that custom html did return, but it was failure to fetch styles.
This answer helped to understand specificity issue https://stackoverflow.com/a/1099252/2848264