### PR TITLE
Fix nginx duplicate MIME type warning

### DIFF
--- a/snippets/error_pages.conf
+++ b/snippets/error_pages.conf
@@ -8,8 +8,6 @@ location ~ /(10[0-3]|2[02][1-9]|30[1-8]|4[0125][0-9]|50[0-9])\.html {
         root /srv/http/default;
         sub_filter '%{HOSTNAME}' $host;
         sub_filter_once off;
-        sub_filter_types text/html;
         allow all;
         internal;
 }
-


### PR DESCRIPTION
This fixes #6. 

The warning is being thrown because `sub_filter_types` always contains `text/html` by default (https://nginx.org/en/docs/http/ngx_http_sub_module.html#sub_filter_types). Explicitly including it throws a duplicate mime type error as it's now technically included twice.